### PR TITLE
Relax upper bound to accommodate dependency on `ansi-terminal-1.0`

### DIFF
--- a/redact.cabal
+++ b/redact.cabal
@@ -50,7 +50,7 @@ library
   other-modules:
       Paths_redact
   build-depends:
-      ansi-terminal >=0.8 && <0.12
+      ansi-terminal >=0.8 && <1.1
     , base >=4.7 && <5
     , text >=1.2.3 && <2.1
   default-language: Haskell2010


### PR DESCRIPTION
`ansi-terminal-1.0` is released on Hackage.

See also https://github.com/commercialhaskell/stackage/issues/6976.

Tested by building with Stack >= 2.9.3 and `stack-bounds.yaml` with these additions/changes:
~~~yaml
extra-deps:
  - ansi-terminal-1.0
  - ansi-terminal-types-0.11.5

allow-newer: true
allow-newer-deps:
- ansi-wl-pprint
~~~